### PR TITLE
Update entry transformation implementation

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,30 +9,24 @@ const App = () => {
     const [amount, setAmount] = useState('');
     const [total, setTotal] = useState(0);
     const [data, setData] = useState([
-      { date: moment().format('LL'), amount: 2000 },
-      { date: moment().subtract(1, 'days').format('LL'), amount: 2500 },
-      { date: moment().subtract(1, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(1, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(1, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(7, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(6, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(5, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(4, 'days').format('LL'), amount: 3500 },
-      { date: moment().subtract(3, 'days').format('LL'), amount: 4500 },
-      { date: moment().subtract(2, 'days').format('LL'), amount: 5500 },
-      { date: moment().subtract(2, 'days').format('LL'), amount: 5500 },
+      { date: moment(), amount: 2000 },
+      { date: moment().subtract(1, 'days'), amount: 2500 },
+      { date: moment().subtract(1, 'days'), amount: 3500 },
+      { date: moment().subtract(1, 'days'), amount: 3500 },
+      { date: moment().subtract(1, 'days'), amount: 3500 },
+      { date: moment().subtract(7, 'days'), amount: 3500 },
+      { date: moment().subtract(6, 'days'), amount: 3500 },
+      { date: moment().subtract(5, 'days'), amount: 3500 },
+      { date: moment().subtract(4, 'days'), amount: 3500 },
+      { date: moment().subtract(3, 'days'), amount: 4500 },
+      { date: moment().subtract(2, 'days'), amount: 5500 },
+      { date: moment().subtract(2, 'days'), amount: 5500 },
     ])
     const [transformedData, setTransformedData] = useState([]);
 
     useEffect(() => {
-      setTransformedData(transformData(groupBy(data, 'date')));
+      setTransformedData(sortEntries(transformEntries(data)));
     }, [data])
-
-    const groupBy = (array, key) =>
-       array.reduce((rv, x) => {
-        (rv[x[key]] = rv[x[key]] || []).push(x);
-        return rv;
-      }, {});
 
     const [gigs, setGigs] = useState([
       {
@@ -42,26 +36,25 @@ const App = () => {
       }
     ]);
 
-    const getDates = () => transformedData.map(pair => pair.date);
+    const getDates = () => transformedData.map(pair => pair.date.format('MM/DD'));
     const getAmounts = () => transformedData.map(pair => pair.amount);
-    const transformData = (groupedData) => {
-      const transformedArray = [];
+    const transformEntries = entries => entries.reduce((entries, {date, amount}) => {
+        let previousEntry = entries.find(({date: previousDate}) => previousDate.isSame(date));
 
-      Object.entries(groupedData).forEach(entry => {
-        const total = entry[1].reduce((total, pair) => total + pair.amount, 0)
-        transformedArray.push({ date: moment(entry[0]).format('MM/DD'), amount: total })
-      })
+        if (!previousEntry) {
+            previousEntry = entries[entries.push({date, amount: 0}) - 1];
+        }
 
-      const sortedArray = transformedArray.sort((a, b) => moment(a['date']).diff(moment(b['date'])))
+        previousEntry.amount = previousEntry.amount + amount;
 
-      return sortedArray;
-    }
+        return entries;
+    }, []);
+    const sortEntries = entries => entries.sort(({date: a}, {date: b}) => a.diff(b));
 
     console.log('DEBUG 🔥', data)
     console.log('The Dates ⏲️', getDates())
     console.log('The Amounts ⏲️', getAmounts())
-    console.log('The GROUPED values are ⏲️', Object.entries(groupBy(data, 'date')))
-    console.log('The Total grouped value 👽', transformData(groupBy(data, 'date')))
+    console.log('The Total grouped value 👽', transformEntries(data))
 
     useEffect(() => {
      setTotal(gigs.reduce((total, gig) => total+Number(gig.amount), 0));
@@ -76,7 +69,7 @@ const App = () => {
       setData([
         ...data,
         { 
-         date: moment().format('LL'),
+         date: moment(),
          amount: Number(amount)
         }
       ]);


### PR DESCRIPTION
This gets rid of the groupBy copy/paste function, transforms the entries
in one step to avoid going through the data multiple times. It also uses
the moment date objects in the data structure to avoid parsing and
converting back and forth between strings and moment date objects when
comparing and sorting.